### PR TITLE
修复了一个可能导致提现失败的bug

### DIFF
--- a/cloudfunctions/ref/index.js
+++ b/cloudfunctions/ref/index.js
@@ -26,7 +26,8 @@ const tenpay = require('tenpay'); //支付核心模块
 exports.main = async(event, context) => {
 
       let userInfo = (await db.collection('user').doc(event.userid).get()).data;
-      if (parseInt(userInfo.parse)<=parseInt(event.num)){
+      //此处应为<而不是<=，否则会造成提现金额恰好等于余额时无法正常提现
+      if (parseInt(userInfo.parse)<parseInt(event.num)){
             return 0;
       }
       //首先获取证书文件


### PR DESCRIPTION
校验提现金额是否合法的时候，提现失败判断条件应该是小于钱包余额而不是小于等于，否则在提现金额等于钱包余额时候可能导致提现失败。